### PR TITLE
Chrome fix for HTML5 load events

### DIFF
--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -813,6 +813,10 @@ function SoundManager(smURL, smID) {
 
     loadeddata: _html5_event(function(e) {
       _s._wD(_h5+'loadeddata: '+this._t.sID);
+      if (!this._t_.loaded) {
+        this._t.duration = this._t.get_html5_duration();
+        this._t._onload(true);
+      }
     }),
 
     loadedmetadata: _html5_event(function(e) {


### PR DESCRIPTION
There's loading woes on other platforms, but hopefully this solves the missing `onload` event problem.
