### PR TITLE
Fix for setting position inside an onposition callback.

### DIFF
--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -1434,9 +1434,9 @@ function SoundManager(smURL, smID) {
       for (i=j; i--;) {
         item = _t._onPositionItems[i];
         if (!item.fired && _t.position >= item.position) {
-          item.method.apply(item.scope,[item.position]);
           item.fired = true;
           _s._onPositionFired++;
+          item.method.apply(item.scope,[item.position]);
         }
       }
       return true;


### PR DESCRIPTION
This changes `processOnPosition` to fire the onposition callback after setting `item.fired`, instead of before.

This allows looping in the form of: `S.onposition(200, function(){ S.setposition(100); });`

There might be a better way to loop only part of a track, but, unfortunately, I don't know of one. And, either way, I don't think it's intentional that the `item.fired` state gets messed up if you call `setposition` from inside the callback.

Also, the other `.js` files should probably be changed/minified accordingly, but I don't know which one of us is supposed to do that.
