### PR TITLE
Mobile Safari should get notifications when it needs further user interaction

### DIFF
--- a/script/soundmanager2-nodebug.js
+++ b/script/soundmanager2-nodebug.js
@@ -1101,6 +1101,12 @@ function SoundManager(smURL, smID) {
       }
       return true;
     };
+    this._onsuspend = function () {
+      if (_t._iO.onsuspend) {
+        _t._iO.onsuspend.apply(_t);
+      }
+      return true;
+    };
     this._onfailure = function(msg, level, code) {
       _t.failures++;
       if (_t._iO.onfailure && _t.failures === 1) {
@@ -1376,6 +1382,7 @@ function SoundManager(smURL, smID) {
     }),
     suspend: _html5_event(function(e) {
       _html5_events.progress.call(this, e);
+      this._t._onsuspend();
     }),
     stalled: _html5_event(function(e) {
     }),

--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -2379,6 +2379,18 @@ function SoundManager(smURL, smID) {
     };
 
     /**
+      Notify Mobile Safari that user action is required
+      to continue playing / loading the audio file.
+     */
+    this._onsuspend = function () {
+      if (_t._iO.onsuspend) {
+        _s._wD("SMSound._onsuspend()");
+        _t._iO.onsuspend.apply(_t);
+      }
+      return true;
+    };
+
+    /**
      * flash 9/movieStar + RTMP-only method, should fire only once at most
      * at this point we just recreate failed sounds rather than trying to reconnect
      */
@@ -2898,6 +2910,7 @@ function SoundManager(smURL, smID) {
 
       _s._wD(_h5+'suspend: '+this._t.sID);
       _html5_events.progress.call(this, e);
+      this._t._onsuspend();
 
     }),
 


### PR DESCRIPTION
Mobile Safari will emit 'suspend' events when a `load` or `play` event was triggered programatically via javascript. If, for instance, you want to show that the sound is loading and the load wasn't triggered by a touch event, then it would be nice to be able to act on the fact that the audio is ready to be loaded / ready to be played.
