### PR TITLE
fix HTML5 validation

### DIFF
--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -4409,7 +4409,7 @@ function SoundManager(smURL, smID) {
     localURL = (_s.altURL || remoteURL),
     swfTitle = 'JS/Flash audio component (SoundManager 2)',
     oEmbed, oMovie, oTarget = _getDocument(), tmp, movieHTML, oEl, extraClass = _getSWFCSS(),
-    s, x, sClass, side = 'auto', isRTL = null,
+    s, x, sClass, side = '1', isRTL = null,
     html = _doc.getElementsByTagName('html')[0];
 
     isRTL = (html && html.dir && html.dir.match(/rtl/i));


### PR DESCRIPTION
width="auto" is not valid HTML5 value for attribute. 
Not sure what the width is used for in the embed of the SWF here, is it needed?
## W3C validator error:

> Syntax of non-negative integer:
> One or more digits (0–9). For example: 42 and 0 are valid, but -273). 
