### PR TITLE
fix create Audio object ror Opera 10 and more

### DIFF
--- a/script/soundmanager2-nodebug.js
+++ b/script/soundmanager2-nodebug.js
@@ -1207,7 +1207,7 @@ function SoundManager(smURL, smID) {
         if (_iO.autoLoad || _iO.autoPlay) {
           _t._a = new Audio(_iO.url);
         } else {
-          _t._a = (_isOpera ? new Audio(null) : new Audio());
+          _t._a = (_isOpera && opera.version() < 10 ? new Audio(null) : new Audio());
         }
         _a = _t._a;
         _a._called_load = false;
@@ -1717,7 +1717,7 @@ function SoundManager(smURL, smID) {
     if (!_s.useHTML5Audio || typeof Audio === 'undefined') {
       return false;
     }
-    var a = (typeof Audio !== 'undefined' ? (_isOpera ? new Audio(null) : new Audio()) : null),
+    var a = (typeof Audio !== 'undefined' ? (_isOpera && opera.version() < 10 ? new Audio(null) : new Audio()) : null),
         item, lookup, support = {}, aF, i;
     function _cp(m) {
       var canPlay, i, j,

--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -2704,7 +2704,7 @@ function SoundManager(smURL, smID) {
         } else {
 
           // null for stupid Opera 9.64 case
-          _t._a = (_isOpera ? new Audio(null) : new Audio());
+          _t._a = (_isOpera && opera.version() < 10 ? new Audio(null) : new Audio());
 
         }
 
@@ -3802,7 +3802,7 @@ function SoundManager(smURL, smID) {
     }
 
     // double-whammy: Opera 9.64 throws WRONG_ARGUMENTS_ERR if no parameter passed to Audio(), and Webkit + iOS happily tries to load "null" as a URL. :/
-    var a = (typeof Audio !== 'undefined' ? (_isOpera ? new Audio(null) : new Audio()) : null),
+    var a = (typeof Audio !== 'undefined' ? (_isOpera && opera.version() < 10 ? new Audio(null) : new Audio()) : null),
         item, lookup, support = {}, aF, i;
 
     function _cp(m) {


### PR DESCRIPTION
Opera > 9
<code>new Audio(null);
// result
&lt;audio preload="auto" src="null"/&gt;</code>
