### PR TITLE
More precise selector for better compatibility

### DIFF
--- a/demo/page-player/script/page-player.js
+++ b/demo/page-player/script/page-player.js
@@ -542,7 +542,7 @@ function PagePlayer() {
   };
   
   this.withinStatusBar = function(o) {
-    return (self.isChildOfClass(o,'controls'));
+    return (self.isChildOfClass(o,'playlist')) && (self.isChildOfClass(o,'controls'));
   };
 
   this.handleClick = function(e) {


### PR DESCRIPTION
The method PagePlayer.withinStatusBar only checks if the element is a child of an element that has the "controls" class. This class name is very generic. 

For example, this conflicts with Twitter Bootstrap forms, which are using the "controls" class too. 

I changed the test to check if the clicked element has a parent with a "playlist" class and a "controls" class. 
