### PR TITLE
minor change to mp3 player button to turn an array into an object

### DIFF
--- a/demo/mp3-player-button/script/mp3-player-button.js
+++ b/demo/mp3-player-button/script/mp3-player-button.js
@@ -24,7 +24,7 @@ function BasicMP3Player() {
   this.excludeClass = 'button-exclude'; // CSS class for ignoring MP3 links
   this.links = [];
   this.sounds = [];
-  this.soundsByURL = [];
+  this.soundsByURL = {};
   this.indexByURL = [];
   this.lastSound = null;
   this.soundCount = 0;


### PR DESCRIPTION
All uses of  `self.soundsByURL` are treated as objects even though `self.soundsByURL` is an array.  This extremely small pull request changes `this.soundsByURL` from an array to an object.
