### PR TITLE
Update buffered property for consistency

### DIFF
--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -2965,7 +2965,7 @@ function SoundManager(smURL, smID) {
       if (!_t.isHTML5) {
         _t.buffered = [{
           'start': 0,
-          'end': _t.duration
+          'end': _t.duration / 1000
         }];
       }
 


### PR DESCRIPTION
Update the buffered property returned in Flash mode to be consistent with HTML5.
Timeranges are supposed to be in seconds (http://www.w3.org/TR/html5/media-elements.html#time-ranges)
