### PR TITLE
Fix GitHub link

### DIFF
--- a/doc/download/index.html
+++ b/doc/download/index.html
@@ -137,7 +137,7 @@ soundManager.setup({
 
 				<p><b>Latest changes:</b> <code>multiShot</code> for polyphonic HTML5 clients, <code>createSound()</code> no longer requires <code>id</code>, auto-<code>reboot()</code> into 100% HTML5 mode and more. See <a href="#history">revision history</a> for details.</p>
 				
-				<p style="padding-top:0.5em"><a href="../../download/soundmanagerv297a-20130512.zip" title="Download SoundManager 2" class="norewrite feature">Download SoundManager 2.97a.20130512</a> or see <a href="https://github.com/scottschiller/soundmanager2/" title="SoundManager 2 on GitHub">on GitHub</a></p>
+				<p style="padding-top:0.5em"><a href="../../download/soundmanagerv297a-20130512.zip" title="Download SoundManager 2" class="norewrite feature">Download SoundManager 2.97a.20130512</a> or see <a href="https://github.com/scottschiller/SoundManager2/" title="SoundManager 2 on GitHub">on GitHub</a></p>
 
 				<p><b>Performance tip:</b> SM2's code size varies from over 150 KB (commented, debug-enabled) down to 11 KB (optimized) over HTTP; check the <a href="../getstarted/#basic-inclusion" title="Including SoundManager 2 on your site: Script build options">pre-optimized builds</a> for details.</p>
 


### PR DESCRIPTION
The lower case GitHub link shows the right repository, instead of redirecting to the correct URL. The lower case URL is not cloneable.
