### PR TITLE
on FF 3.6 with no flash, onLoad event is not triggered

### DIFF
--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -3395,7 +3395,7 @@ function SoundManager(smURL, smID) {
 
   getDocument = function() {
 
-    return (doc.body || doc._docElement || doc.getElementsByTagName('div')[0]);
+    return (doc.body || doc.getElementsByTagName('div')[0]);
 
   };
 


### PR DESCRIPTION
code to reproduce the error:
                    soundManager.createSound({
                        id: 'mysound',
                        url: '/sounds/mysound.ogg',
                        autoLoad: true,
                        autoPlay: true,
                        onload: function(){
                           alert('loaded');
                                }
                    });
adding s._a.load(); on line 2937, triggers the onload event.
