### PR TITLE
allow setup when DOM is in 'complete' _and_ 'interactive' state

### DIFF
--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -351,7 +351,7 @@ function SoundManager(smURL, smID) {
 
       // special case 2: If lazy-loading SM2 (DOMContentLoaded has already happened) and user calls setup() with url: parameter, try to init ASAP.
 
-      if (!didDCLoaded && options.url !== _undefined && doc.readyState === 'complete') {
+      if (!didDCLoaded && options.url !== _undefined && doc.readyState !== 'loading') {
         setTimeout(domContentLoaded, 1);
       }
 


### PR DESCRIPTION
We use SM2 internally with requirejs and also we bundle up SM2 with our own library that is loaded in a script tag. To keep initialization of SM2 consistent in the diff environments we use 'SM2_DEFER = true' and then create and 'setup' the SoundManager instance ourselves. 

We ran into a problem when using the deferred setup and jQuery's document ready handler, where the 'ready' event is never called:

```
<script> SM2_DEFER = true; </script>
<script src="SoundManager2.js"></script>
<script src="jquery.js"></script>
<script>
$(function() {
  // .... yadda yadda yadda
  window.soundManager = new window.SoundManager();
  window.soundManager.setup({ /* .. yadda yadda yadda .. */);

  // the 'ready' event from soundManager is never called
})
</script>
```

It seems that the document.readyState at that point in time we call 'setup()' is 'interactive', and not 'complete', so the code in 'setup()' that calls 'domContentLoaded()' doesn't get called. This patch changes the logic so that 'domContentLoaded()' will still be called when the page is in an 'interactive' but not yet 'complete' state.
