### PR TITLE
DOMContentLoaded/readyState=='interactive' fix

### DIFF
--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -5914,6 +5914,10 @@ console.log('updated metadata', s.metadata);
 
     // catch edge case of initComplete() firing after window.load()
     windowLoaded = true;
+
+    // catch case where DOMContentLoaded has been sent, but we're still in doc.readyState = 'interactive'
+    domContentLoaded();
+
     event.remove(window, 'load', winOnLoad);
 
   };


### PR DESCRIPTION
We use SM2 internally with requirejs and also we bundle up SM2 with our own library that is loaded in a script tag. To keep initialization of SM2 consistent in the diff environments we use 'SM2_DEFER = true' and then create and 'setup' the SoundManager instance ourselves rather than have it initialize things as soon as the file is loaded.

We ran into a problem when using the deferred setup and jQuery's document ready handler, where the 'ready' event is never called:

```
<script>var SM2_DEFER = true; </script>
<script src="SoundManager2.js"></script>
<script src="jquery.js"></script>
<script>
$(function() {
  // .... yadda yadda yadda
  window.soundManager = new window.SoundManager();
  window.soundManager.setup({
    // ... yadda yadda yadda
   onready: {
      console.log('I am never called!');
   } 
});
})
</script>
```

It seems that the document.readyState at the point in time we call 'soundManager.setup()' is 'interactive', and not 'complete', but the 'DOMContentLoaded' event has already been sent, so 'domContentLoaded' is never called and we get no sound.

This fix basically duplicates what the jquery guys did, which is add a fallback 'load' handler for the window object. See the inspiration here:

https://github.com/jquery/jquery/blob/master/src/core/ready.js
