### PR TITLE
Sets page title to link title

### DIFF
--- a/demo/page-player/script/page-player.js
+++ b/demo/page-player/script/page-player.js
@@ -664,7 +664,7 @@ function PagePlayer() {
           oPeak: self.select('peak',oLI),
           oGraph: self.select('spectrum-box',oLI),
           className: self.css.sPlaying,
-          originalTitle: o.innerHTML,
+          originalTitle: o.title || o.textContent,
           metadata: null
         };
 


### PR DESCRIPTION
I know this is just a demo script, but I'm using it in production and I changed this line; figured I'd send it your way if you care to adopt it.
