### PR TITLE
Add a package.json file to allow npm installs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "SoundManager",
+  "version": "2.97.20140901",
+  "description": "A JavaScript Sound API supporting MP3, MPEG4 and HTML5 audio + (experimental) RTMP, providing reliable cross-browser/platform audio control in as little as 10 KB.",
+  "main": "script/soundmanager2.js",
+  "directories": {
+    "doc": "doc"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scottschiller/SoundManager2"
+  },
+  "keywords": [
+    "browser",
+    "audio",
+    "sound",
+    "mp3",
+    "mpeg4",
+    "html5"
+  ],
+  "author": "Scott Schiller (http://schillmania.com/)",
+  "license": "BSD",
+  "bugs": {
+    "url": "https://github.com/scottschiller/SoundManager2/issues"
+  },
+  "homepage": "https://github.com/scottschiller/SoundManager2"
+}


### PR DESCRIPTION
I'm in the process of migrating from bower to npm for installing my frontend libraries, but I ran into an issue with SoundManager. Since it does not include a package.json file, I cannot install it even using a github url.

This PR adds a package.json file with author credentials. I versioned it at a pseudo-semver equivalent of the most recent release version. It's up to you if you want to publish it on npm, but having the file present in the repo would save a lot of people an extra build step.

I know you say in the readme to submit to the latest dev branch, but it didn't look like you were creating new dev branches any more.

Thanks.
