### PR TITLE
Fire onstop() also when destroying a sound

### DIFF
--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -530,10 +530,11 @@ function SoundManager(smURL, smID) {
 
     var oS = sm2.sounds[sID], i;
 
-    // Disable all callbacks while the sound is being destroyed
-    oS._iO = {};
-
     oS.stop();
+    
+    // Disable all callbacks after stop(), when the sound is being destroyed
+    oS._iO = {};
+    
     oS.unload();
 
     for (i = 0; i < sm2.soundIDs.length; i++) {


### PR DESCRIPTION
Had to go trough the source to find the "right" way to call a onstop callback when destroying a sound (which is playing)...destroySound() kills all callbacks first, then calls stop() on the sound...IMO this shouldn't be the case (and didn't cause any problem so far), e.g. it would be handy if we can rely on the onstop() callback whenever stop() on a sound is called, also when it's destroyed while playing...

right now what I have to do to reach the onstop() callback is 

``` js
sound.stop();
sound.destruct();

// instead of just
sound.destruct();
```

so the change I made is just moving the callback-remover below the .stop() call...not sure if anything speaks against this, if so I'd be very interested in =)
