### PR TITLE
add `window.soundManager` in AMD Module

### DIFF
--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -6050,6 +6050,7 @@ if (typeof module === 'object' && module && typeof module.exports === 'object') 
 } else if (typeof define === 'function' && define.amd) {
 
   // AMD - requireJS
+  window.soundManager = soundManager;
 
   define('SoundManager', [], function() {
     return {


### PR DESCRIPTION
So the AMD Module also need this due to Flash
https://github.com/scottschiller/SoundManager2/blob/master/script/soundmanager2.js#L6039
