### PR TITLE
Always default to http for IE when accessing cab file

### DIFF
--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -2593,7 +2593,7 @@ function SoundManager(smURL, smID) {
     this._processOnPosition = function() {
 
       var i, item, j = onPositionItems.length;
-		
+
       if (!j || !s.playState || onPositionFired >= j) {
         return false;
       }
@@ -2607,7 +2607,7 @@ function SoundManager(smURL, smID) {
 		  j = onPositionItems.length; //  reset j -- onPositionItems.length can be changed in the item callback above... occasionally breaking the loop.
         }
       }
-	
+
       return true;
 
     };
@@ -5295,7 +5295,7 @@ featureCheck = function() {
       // IE is "special".
       oMovie = doc.createElement('div');
       movieHTML = [
-        '<object id="' + smID + '" data="' + smURL + '" type="' + oEmbed.type + '" title="' + oEmbed.title +'" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" codebase="' + http+'download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=6,0,40,0">',
+        '<object id="' + smID + '" data="' + smURL + '" type="' + oEmbed.type + '" title="' + oEmbed.title +'" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=6,0,40,0">',
         param('movie', smURL),
         param('AllowScriptAccess', sm2.allowScriptAccess),
         param('quality', oEmbed.quality),


### PR DESCRIPTION
Thanks for the great plugin!

I have been encountering the problem that I constantly get 404 errors on IE when using Soundmanager2.

It tries to access `download.macromedia.com/....` from the current url rather that using the absolute url.
eg. If my sire is hosted at `http://www.example.com/test`, it tries to access `http://www.example.com/download.macromedia.com/...` and spits out a 404 error.

Please do suggest if this is a valid fix and if refactoring is required.

Thanks
