### PR TITLE
Manually set useGlobalHTML5Audio to true with forceUseGlobalHTML5Audio option

### DIFF
--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -81,7 +81,7 @@ function SoundManager(smURL, smID) {
     'allowScriptAccess': 'always',      // for scripting the SWF (object/embed property), 'always' or 'sameDomain'
     'useFlashBlock': false,             // *requires flashblock.css, see demos* - allow recovery from flash blockers. Wait indefinitely and apply timeout CSS to SWF, if applicable.
     'useHTML5Audio': true,              // use HTML5 Audio() where API is supported (most Safari, Chrome versions), Firefox (no MP3/MP4.) Ideally, transparent vs. Flash API where possible.
-    'forceUseGlobalHTML5Audio': false,  //
+    'forceUseGlobalHTML5Audio': false,  // if true, ensures that useGlobalHTML5Audio is true.
     'html5Test': /^(probably|maybe)$/i, // HTML5 Audio() format support test. Use /^probably$/i; if you want to be more conservative.
     'preferFlash': false,               // overrides useHTML5audio, will use Flash for MP3/MP4/AAC if present. Potential option if HTML5 playback with these formats is quirky.
     'noSWFCache': false,                // if true, appends ?ts={date} to break aggressive SWF caching.

--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -81,6 +81,7 @@ function SoundManager(smURL, smID) {
     'allowScriptAccess': 'always',      // for scripting the SWF (object/embed property), 'always' or 'sameDomain'
     'useFlashBlock': false,             // *requires flashblock.css, see demos* - allow recovery from flash blockers. Wait indefinitely and apply timeout CSS to SWF, if applicable.
     'useHTML5Audio': true,              // use HTML5 Audio() where API is supported (most Safari, Chrome versions), Firefox (no MP3/MP4.) Ideally, transparent vs. Flash API where possible.
+    'forceUseGlobalHTML5Audio': false,  //
     'html5Test': /^(probably|maybe)$/i, // HTML5 Audio() format support test. Use /^probably$/i; if you want to be more conservative.
     'preferFlash': false,               // overrides useHTML5audio, will use Flash for MP3/MP4/AAC if present. Potential option if HTML5 playback with these formats is quirky.
     'noSWFCache': false,                // if true, appends ?ts={date} to break aggressive SWF caching.
@@ -349,6 +350,10 @@ function SoundManager(smURL, smID) {
     // TODO: defer: true?
 
     assign(options);
+
+    if (sm2.forceUseGlobalHTML5Audio) {
+      useGlobalHTML5Audio = true;
+    }
 
     // special case 1: "Late setup". SM2 loaded normally, but user didn't assign flash URL eg., setup({url:...}) before SM2 init. Treat as delayed init.
 


### PR DESCRIPTION
Part of @snadn's pending [pull request](https://github.com/scottschiller/SoundManager2/pull/52) identifies an issue we're dealing with--Safari won't create new `<audio>` tags when the tab is backgrounded. There's already the internal `useGlobalHTML5Audio` flag, which gets switched on for iDevices, to re-use the initial audio tag. Modifying @snadn's code, this PR creates a `forceUseGlobalHTML5Audio` option which will manually switch on `useGlobalHTML5Audio`. This lets us fix our safari background-tab issue when setting up soundManager:

```javascript
soundManager.setup({
  forceUseGlobalHTML5Audio: true
});
```