### PR TITLE
checking if defaultItem is defined before setting title

### DIFF
--- a/demo/bar-ui/script/bar-ui.js
+++ b/demo/bar-ui/script/bar-ui.js
@@ -1270,7 +1270,9 @@
 
       playlistController.select(defaultItem);
 
-      setTitle(defaultItem);
+      if(defaultItem){
+        setTitle(defaultItem);
+      }
 
       utils.events.add(dom.o, 'mousedown', handleMouseDown);
 


### PR DESCRIPTION
This avoids a TypeError when starting out with a empty playlist.

I use bar-ui in a setting where the users playlist is empty at the beginning and he can fill the playlist up by adding songs to it. Without checking if the defaultItem is set, a TypeError occurs and empty playlists are impossible.