### PR TITLE
bower.json: Ignore 'demo' and 'doc' folders.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,8 @@
     "**/.*",
     "node_modules",
     "bower_components",
+    "demo",
+    "doc",
     "test",
     "tests",
     "tasks",


### PR DESCRIPTION
This removes the «demo» and «doc» folders from the bower package, they should not be there.

See https://github.com/scottschiller/SoundManager2/pull/61#issuecomment-80792162

> `demo` is 10.5 MiB, `doc` is 1.4 MiB, all the rest is 0.6 MiB.

This reduces the size of the bower package 20 times.