### PR TITLE
Protects the comparison against floating point precision problems.

### DIFF
--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -2326,7 +2326,7 @@ function SoundManager(smURL, smID) {
         // Set the position in the canplay handler if the sound is not ready yet
         if (s._html5_canplay) {
 
-          if (s._a.currentTime !== position1K) {
+          if (s._a.currentTime.toFixed(3) !== position1K.toFixed(3)) {
 
             /**
              * DOM/JS errors/exceptions to watch out for:


### PR DESCRIPTION
Safari raises a problem when currentTime is called twice with the same or similar values. Look at https://jsfiddle.net/dotpao/LutLa61c/5/

So to be sure that the currentTime is not called twice I've rounded to 3 decimal positions inside the condition.