### PR TITLE
updated package.json to bring in src folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "2.97.20140901",
   "description": "A JavaScript Sound API supporting MP3, MPEG4 and HTML5 audio + RTMP, providing reliable cross-browser/platform audio control in as little as 11 KB.",
   "main": "script/soundmanager2.js",
-  "directories": {
-    "lib": "./script"
-  },
+  "directories": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Made a change to the package.json file for npm, as initially it wasn't bringing the `./src` folder into the install. Removing `lib:"./script"` fixes the problem
