### PR TITLE
Fix bar UI to work with mobile.

### DIFF
--- a/demo/bar-ui/script/bar-ui.js
+++ b/demo/bar-ui/script/bar-ui.js
@@ -193,15 +193,6 @@
 
         },
 
-        onbufferchange: function(isBuffering) {
-
-          if (isBuffering) {
-            utils.css.add(dom.o, 'buffering');
-          } else {
-            utils.css.remove(dom.o, 'buffering');
-          }
-
-        },
 
         onplay: function() {
           utils.css.swap(dom.o, 'paused', 'playing');
@@ -367,7 +358,20 @@
 
         soundObject.play({
           url: link.href,
-          position: 0
+          position: 0,
+          onbufferchange: function(isBuffering) {
+
+            if (isBuffering) {
+              utils.css.add(dom.o, 'buffering');
+            } else {
+              utils.css.remove(dom.o, 'buffering');
+            }
+            // Fixes an issue with playback not starting on mobile
+            if (this.duration > 1500) {
+              this.pause();
+              this.resume();
+            }
+          }
         });
 
       }


### PR DESCRIPTION
Fixes #93. 

For some reason, pausing and resuming on a bufferchange and a duration above 1500 did the trick, although I'm not exactly sure why.