### PR TITLE
Update bar-ui.js

### DIFF
--- a/demo/bar-ui/script/bar-ui.js
+++ b/demo/bar-ui/script/bar-ui.js
@@ -561,7 +561,7 @@
         }
 
         // update selected offset, too.
-        offset = findOffsetFromItem(item);
+        offset = findOffsetFromItem(liElement);
 
         data.selectedIndex = offset;
 


### PR DESCRIPTION
When using a playlist that has divs nested inside li elements, clicking the "next" button on the player interface results in the parent div of the next playlist link being passed to findOffsetFromItem, which returns -1 and resets the playlist back to the first item. Passing the "liElement" instead of the "item" fixes this. You will not see this problem when testing the demo on http://www.schillmania.com/projects/soundmanager2/demo/bar-ui/, because the example playlists only have divs in the first playlist item. If you change the playlists to have multiple items containing divs you'll see that it breaks the "next" button functionality.