### PR TITLE
+mixcrate to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -40,6 +40,7 @@ A few nifty sites that have implemented SM2 for driving audio:
     * Tidal
     * Beats
     * Songza
+    * Mixcrate
     * Earbits
     * freesound.org
     * last.fm


### PR DESCRIPTION
Hey @scottschiller 

Hope all is well. Several months ago, Mixcrate launched an embeddable player which uses SoundManager2 (:+1:) You can trace the source of SoundManager2 from the URL below. 

This pull-request adds Mixcrate to your examples in the README.

`<iframe src="http://embed.mixcrate.com/494084"></iframe>`

Screenshot of embedded player on DJ Qbert's Web site:
<img width="378" alt="screen shot 2015-10-17 at 8 20 48 pm" src="https://cloud.githubusercontent.com/assets/1373129/10562343/9882234a-750c-11e5-805f-5d7327be1fe7.png">

