### PR TITLE
Add better class names to icons to avoid css conflicts on bar-ui demo

### DIFF
--- a/demo/bar-ui/css/bar-ui.css
+++ b/demo/bar-ui/css/bar-ui.css
@@ -521,16 +521,16 @@
  -ms-interpolation-mode: bicubic;
 }
 
-.play-pause,
-.play-pause:hover,
-.paused .play-pause:hover {
+.sm2-icon-play-pause,
+.sm2-icon-play-pause:hover,
+.paused .sm2-icon-play-pause:hover {
  background-image: url(../image/icomoon/entypo-25px-ffffff/PNG/play.png);
  background-image: none, url(../image/icomoon/entypo-25px-ffffff/SVG/play.svg);
  background-size: 67.5%;
  background-position: 40% 53%;
 }
 
-.playing .play-pause {
+.playing .sm2-icon-play-pause {
  background-image: url(../image/icomoon/entypo-25px-ffffff/PNG/pause.png);
  background-image: none, url(../image/icomoon/entypo-25px-ffffff/SVG/pause.svg);
  background-size: 57.6%;
@@ -556,50 +556,50 @@
  background-image: none, url(../image/icomoon/entypo-25px-000000/SVG/volume.svg);
 }
 
-.menu {
+.sm2-icon-menu {
  background-image: url(../image/icomoon/entypo-25px-ffffff/PNG/list2.png);
  background-image: none, url(../image/icomoon/entypo-25px-ffffff/SVG/list2.svg);
  background-size: 58%;
  background-position: 54% 51%;
 }
 
-.previous {
+.sm2-icon-previous {
  background-image: url(../image/icomoon/entypo-25px-ffffff/PNG/first.png);
  background-image: none, url(../image/icomoon/entypo-25px-ffffff/SVG/first.svg);
 }
 
-.next {
+.sm2-icon-next {
  background-image: url(../image/icomoon/entypo-25px-ffffff/PNG/last.png);
  background-image: none, url(../image/icomoon/entypo-25px-ffffff/SVG/last.svg);
 }
 
-.previous,
-.next {
+.sm2-icon-previous,
+.sm2-icon-next {
  background-size: 49.5%;
  background-position: 50% 50%;
 }
 
 
-.sm2-extra-controls .previous,
-.sm2-extra-controls .next {
+.sm2-extra-controls .sm2-icon-previous,
+.sm2-extra-controls .sm2-icon-next {
  backgound-size: 53%;
 }
 
-.shuffle {
+.sm2-icon-shuffle {
  background-image: url(../image/icomoon/entypo-25px-ffffff/PNG/shuffle.png);
  background-image: none, url(../image/icomoon/entypo-25px-ffffff/SVG/shuffle.svg);
  background-size: 45%;
  background-position: 50% 50%;
 }
 
-.repeat {
+.sm2-icon-repeat {
  background-image: url(../image/icomoon/entypo-25px-ffffff/PNG/loop.png);
  background-image: none, url(../image/icomoon/entypo-25px-ffffff/SVG/loop.svg);
  background-position: 50% 43%;
  background-size: 54%;
 }
 
-.sm2-extra-controls .repeat {
+.sm2-extra-controls .sm2-icon-repeat {
  background-position: 50% 45%;
 }
 
@@ -710,7 +710,7 @@
  background-size: 72%;
  background-position: 50%;
  background-repeat: no-repeat;
- display: none; 
+ display: none;
 }
 
 .playing.buffering .sm2-progress-ball .icon-overlay {
@@ -898,7 +898,7 @@
 .sm2-bar-ui.dark-text ul li.selected a {
  background-color: rgba(255,255,255,0.1);
  background-image: url(../image/black-10.png);
- background-image: none, none; 
+ background-image: none, none;
 }
 
 .sm2-bar-ui .disabled {
@@ -940,7 +940,7 @@
  background: rgba(0,0,0,0.33);
  border-radius: 10px;
 }
- 
+
 .sm2-playlist-wrapper ul::-webkit-scrollbar-thumb {
  border-radius: 10px;
  background: #fff;

--- a/demo/bar-ui/index.html
+++ b/demo/bar-ui/index.html
@@ -36,7 +36,7 @@
 
   <div class="sm2-inline-element sm2-button-element">
    <div class="sm2-button-bd">
-    <a href="#play" class="sm2-inline-button play-pause">Play / pause</a>
+    <a href="#play" class="sm2-inline-button sm2-icon-play-pause">Play / pause</a>
    </div>
   </div>
 
@@ -74,7 +74,7 @@
 
   <div class="sm2-inline-element sm2-button-element sm2-menu">
    <div class="sm2-button-bd">
-    <a href="#menu" class="sm2-inline-button menu">menu</a>
+    <a href="#menu" class="sm2-inline-button sm2-icon-menu">menu</a>
    </div>
   </div>
 
@@ -89,7 +89,7 @@
   <!-- playlist content is mirrored here -->
 
   <div class="sm2-playlist-wrapper">
-    
+
     <ul class="sm2-playlist-bd">
 
      <!-- example: playable link, "buy" link, "download" link -->
@@ -133,9 +133,9 @@
      <li><a href="http://freshly-ground.com/data/audio/sm2/20130320%20-%20Po%27ipu%20Beach%20Waves.ogg">Po'ipu Beach Waves (OGG)</a></li>
      <li><a href="http://freshly-ground.com/data/audio/sm2/bottle-pop.wav">A corked beer bottle (WAV)</a></li>
      <li><a href="../../demo/_mp3/rain.mp3">Rain</a></li>
-    
+
     </ul>
-  
+
   </div>
 
   <div class="sm2-extra-controls">
@@ -143,18 +143,18 @@
    <div class="bd">
 
     <div class="sm2-inline-element sm2-button-element">
-     <a href="#prev" title="Previous" class="sm2-inline-button previous">&lt; previous</a>
+     <a href="#prev" title="Previous" class="sm2-inline-button sm2-icon-previous">&lt; previous</a>
     </div>
 
     <div class="sm2-inline-element sm2-button-element">
-     <a href="#next" title="Next" class="sm2-inline-button next">&gt; next</a>
+     <a href="#next" title="Next" class="sm2-inline-button sm2-icon-next">&gt; next</a>
     </div>
 
     <!-- not implemented -->
     <!--
     <div class="sm2-inline-element sm2-button-element disabled">
      <div class="sm2-button-bd">
-      <a href="#repeat" title="Repeat playlist" class="sm2-inline-button repeat">&infin; repeat</a>
+      <a href="#repeat" title="Repeat playlist" class="sm2-inline-button sm2-icon-repeat">&infin; repeat</a>
      </div>
     </div>
     -->
@@ -162,7 +162,7 @@
     <!-- not implemented -->
     <!--
     <div class="sm2-inline-element sm2-button-element disabled">
-     <a href="#shuffle" title="Shuffle" class="sm2-inline-button shuffle">shuffle</a>
+     <a href="#shuffle" title="Shuffle" class="sm2-inline-button sm2-icon-shuffle">shuffle</a>
     </div>
     -->
 
@@ -187,7 +187,7 @@
 
   <div class="sm2-inline-element sm2-button-element">
    <div class="sm2-button-bd">
-    <a href="#play" class="sm2-inline-button play-pause">Play / pause</a>
+    <a href="#play" class="sm2-inline-button sm2-icon-play-pause">Play / pause</a>
    </div>
   </div>
 
@@ -225,19 +225,19 @@
 
   <div class="sm2-inline-element sm2-button-element">
    <div class="sm2-button-bd">
-    <a href="#prev" title="Previous" class="sm2-inline-button previous">&lt; previous</a>
+    <a href="#prev" title="Previous" class="sm2-inline-button sm2-icon-previous">&lt; previous</a>
    </div>
   </div>
 
   <div class="sm2-inline-element sm2-button-element">
    <div class="sm2-button-bd">
-    <a href="#next" title="Next" class="sm2-inline-button next">&gt; next</a>
+    <a href="#next" title="Next" class="sm2-inline-button sm2-icon-next">&gt; next</a>
    </div>
   </div>
 
   <div class="sm2-inline-element sm2-button-element sm2-menu">
    <div class="sm2-button-bd">
-     <a href="#menu" class="sm2-inline-button menu">menu</a>
+     <a href="#menu" class="sm2-inline-button sm2-icon-menu">menu</a>
    </div>
   </div>
 
@@ -252,9 +252,9 @@
   <!-- playlist content is mirrored here -->
 
   <div class="sm2-playlist-wrapper">
-    
+
     <ul class="sm2-playlist-bd">
-     
+
      <!-- item with "download" link -->
      <li>
       <div class="sm2-row">
@@ -266,7 +266,7 @@
        </div>
       </div>
      </li>
-     
+
      <!-- standard one-line items -->
      <li><a href="http://freshly-ground.com/data/audio/sm2/SonReal%20-%20People%20Asking.mp3"><b>SonReal</b> - People Asking <span class="label">Explicit</span></a></li>
      <li><a href="http://freshly-ground.com/data/audio/sm2/SonReal%20-%20Already%20There%20Remix%20ft.%20Rich%20Kidd%2C%20Saukrates.mp3"><b>SonReal</b> - Already There Remix ft. Rich Kidd, Saukrates <span class="label">Explicit</span></a></li>
@@ -280,9 +280,9 @@
      <li><a href="http://freshly-ground.com/data/audio/sm2/20130320%20-%20Po%27ipu%20Beach%20Waves.ogg">Po'ipu Beach Waves (OGG)</a></li>
      <li><a href="http://freshly-ground.com/data/audio/sm2/bottle-pop.wav">A corked beer bottle (WAV)</a></li>
      <li><a href="../../demo/_mp3/rain.mp3">Rain</a></li>
-    
+
     </ul>
-  
+
   </div>
 
   <div class="sm2-extra-controls">
@@ -290,23 +290,23 @@
    <div class="bd">
 
     <div class="sm2-inline-element sm2-button-element">
-     <a href="#prev" title="Previous" class="sm2-inline-button previous">&lt; previous</a>
+     <a href="#prev" title="Previous" class="sm2-inline-button sm2-icon-previous">&lt; previous</a>
     </div>
 
     <div class="sm2-inline-element sm2-button-element">
-     <a href="#next" title="Next" class="sm2-inline-button next">&gt; next</a>
+     <a href="#next" title="Next" class="sm2-inline-button sm2-icon-next">&gt; next</a>
     </div>
 
     <!-- not implemented -->
     <!--
     <div class="sm2-inline-element sm2-button-element disabled">
      <div class="sm2-button-bd">
-      <a href="#repeat" title="Repeat playlist" class="sm2-inline-button repeat">&infin; repeat</a>
+      <a href="#repeat" title="Repeat playlist" class="sm2-inline-button sm2-icon-repeat">&infin; repeat</a>
      </div>
     </div>
 
     <div class="sm2-inline-element sm2-button-element disabled">
-     <a href="#shuffle" title="Shuffle" class="sm2-inline-button shuffle">shuffle</a>
+     <a href="#shuffle" title="Shuffle" class="sm2-inline-button sm2-icon-shuffle">shuffle</a>
     </div>
     -->
 
@@ -331,7 +331,7 @@
 
   <div class="sm2-inline-element sm2-button-element">
    <div class="sm2-button-bd">
-    <a href="#play" class="sm2-inline-button play-pause">Play / pause</a>
+    <a href="#play" class="sm2-inline-button sm2-icon-play-pause">Play / pause</a>
    </div>
   </div>
 
@@ -400,7 +400,7 @@
 
   <div class="sm2-inline-element sm2-button-element">
    <div class="sm2-button-bd">
-    <a href="#play" class="sm2-inline-button play-pause">Play / pause</a>
+    <a href="#play" class="sm2-inline-button sm2-icon-play-pause">Play / pause</a>
    </div>
   </div>
 
@@ -540,7 +540,7 @@
  <h3>HTML classname options</h3>
 
  <div style="margin-top:1em">
-  <button id="fullwidth">full width</button> 
+  <button id="fullwidth">full width</button>
   <!-- <button id="fixed">fixed</button> -->
   <button id="textured">texture</button>
   <button id="dark">dark/light text</button>
@@ -606,7 +606,7 @@
 
   <div class="sm2-inline-element sm2-button-element">
    <div class="sm2-button-bd">
-    <a href="#play" class="sm2-inline-button play-pause">Play / pause</a>
+    <a href="#play" class="sm2-inline-button sm2-icon-play-pause">Play / pause</a>
    </div>
   </div>
 
@@ -644,19 +644,19 @@
 
   <div class="sm2-inline-element sm2-button-element">
    <div class="sm2-button-bd">
-    <a href="#prev" title="Previous" class="sm2-inline-button previous">&lt; previous</a>
+    <a href="#prev" title="Previous" class="sm2-inline-button sm2-icon-previous">&lt; previous</a>
    </div>
   </div>
 
   <div class="sm2-inline-element sm2-button-element">
    <div class="sm2-button-bd">
-    <a href="#next" title="Next" class="sm2-inline-button next">&gt; next</a>
+    <a href="#next" title="Next" class="sm2-inline-button sm2-icon-next">&gt; next</a>
    </div>
   </div>
 
   <div class="sm2-inline-element sm2-button-element">
    <div class="sm2-button-bd">
-    <a href="#repeat" title="Repeat playlist" class="sm2-inline-button repeat">&infin; repeat</a>
+    <a href="#repeat" title="Repeat playlist" class="sm2-inline-button sm2-icon-repeat">&infin; repeat</a>
    </div>
   </div>
 
@@ -664,14 +664,14 @@
   <!--
   <div class="sm2-inline-element sm2-button-element disabled">
    <div class="sm2-button-bd">
-    <a href="#shuffle" title="Shuffle" class="sm2-inline-button shuffle">shuffle</a>
+    <a href="#shuffle" title="Shuffle" class="sm2-inline-button sm2-icon-shuffle">shuffle</a>
    </div>
   </div>
   -->
 
   <div class="sm2-inline-element sm2-button-element sm2-menu">
    <div class="sm2-button-bd">
-    <a href="#menu" class="sm2-inline-button menu">menu</a>
+    <a href="#menu" class="sm2-inline-button sm2-icon-menu">menu</a>
    </div>
   </div>
 
@@ -714,9 +714,9 @@
      <li><a href="http://freshly-ground.com/data/audio/sm2/20130320%20-%20Po%27ipu%20Beach%20Waves.ogg">Po'ipu Beach Waves (OGG)</a></li>
      <li><a href="http://freshly-ground.com/data/audio/sm2/bottle-pop.wav">A corked beer bottle (WAV)</a></li>
      <li><a href="../../demo/_mp3/rain.mp3">Rain</a></li>
-    
+
     </ul>
-  
+
   </div>
 
  </div>


### PR DESCRIPTION
Changes for the . Add “sm2-icon-“ on the icons so their styles won’t
conflict with other CSS on the page, like the “.menu” class on Zurb’s
Foundation 6