### PR TITLE
On mobile devices that support HTML5 - IOS specifically, an <audio> tag element must exist to actually play a song loaded from a server to prevent "Failed to execute 'play' on 'HTMLMediaElement': API can only be initiated by a user gesture."  

### DIFF
--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -647,17 +647,24 @@ function SoundManager(smURL, smID) {
   };
 
   /**
-   * Gets the <audio> element that already exists in the DOM
+   * Create the <audio> element in the DOM
    *
    * @return {HTMLAudioElement} The audio element created in the dom
    */
-   this.getAudioTagElement = function(src) {
+   this.createAudioElement = function (src) {
 
-    var a = doc.getElementById('sm2-html5Audio');
-    a.src = (src) ? src : '';
-    return a;
+    try {
+      var d = doc.createElement('div'),
+          a = doc.createElement('audio');
+      d.id = 'sm2-html5Audio-wrapper';
+      a.id = 'sm2-html5Audio';
+      a.src = (src) ? src : '';
+      doc.body.appendChild(d).appendChild(a);
+    } catch (e) {} finally {
+      return a;
+    }
 
-   };
+  };
 
   /**
    * Calls the unload() method of a SMSound object by ID.
@@ -2154,7 +2161,7 @@ function SoundManager(smURL, smID) {
 
             sm2._wD(s.id + ': Cloning Audio() for instance #' + s.instanceCount + '...');
 
-            audioClone = (mobileHTML5) ? sm2.getAudioTagElement(s._iO.url) : new Audio(s._iO.url);
+            audioClone = (mobileHTML5) ? sm2.createAudioElement(s._iO.url) : new Audio(s._iO.url);
 
             onended = function() {
               event.remove(audioClone, 'ended', onended);
@@ -3109,14 +3116,14 @@ function SoundManager(smURL, smID) {
 
         if (instanceOptions.autoLoad || instanceOptions.autoPlay) {
 
-          s._a = (mobileHTML5) ? sm2.getAudioTagElement(instanceOptions.url) : new Audio(instanceOptions.url);
+          s._a = (mobileHTML5) ? sm2.createAudioElement(instanceOptions.url) : new Audio(instanceOptions.url);
 
           s._a.load();
 
         } else {
 
           // null for stupid Opera 9.64 case
-          s._a = (mobileHTML5) ? sm2.getAudioTagElement() : (isOpera && opera.version() < 10 ? new Audio(null) : new Audio());
+          s._a = (mobileHTML5) ? sm2.createAudioElement() : (isOpera && opera.version() < 10 ? new Audio(null) : new Audio());
 
         }
 
@@ -4337,7 +4344,7 @@ function SoundManager(smURL, smID) {
     }
 
     // double-whammy: Opera 9.64 throws WRONG_ARGUMENTS_ERR if no parameter passed to Audio(), and Webkit + iOS happily tries to load "null" as a URL. :/
-    var a = (mobileHTML5) ? sm2.getAudioTagElement() : (Audio !== _undefined ? (isOpera && opera.version() < 10 ? new Audio(null) : new Audio()) : null),
+    var a = (mobileHTML5) ? sm2.createAudioElement() : (Audio !== _undefined ? (isOpera && opera.version() < 10 ? new Audio(null) : new Audio()) : null),
         item, lookup, support = {}, aF, i;
 
     function cp(m) {

--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -4344,7 +4344,7 @@ function SoundManager(smURL, smID) {
     }
 
     // double-whammy: Opera 9.64 throws WRONG_ARGUMENTS_ERR if no parameter passed to Audio(), and Webkit + iOS happily tries to load "null" as a URL. :/
-    var a = (mobileHTML5) ? sm2.createAudioElement() : (Audio !== _undefined ? (isOpera && opera.version() < 10 ? new Audio(null) : new Audio()) : null),
+    var a = (Audio !== _undefined ? (isOpera && opera.version() < 10 ? new Audio(null) : new Audio()) : null),
         item, lookup, support = {}, aF, i;
 
     function cp(m) {

--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -2161,7 +2161,7 @@ function SoundManager(smURL, smID) {
 
             sm2._wD(s.id + ': Cloning Audio() for instance #' + s.instanceCount + '...');
 
-            audioClone = (mobileHTML5) ? this.createAudioElement(s._iO.url) : new Audio(s._iO.url);
+            audioClone = (mobileHTML5) ? sm2.createAudioElement(s._iO.url) : new Audio(s._iO.url);
 
             onended = function() {
               event.remove(audioClone, 'ended', onended);
@@ -3116,14 +3116,14 @@ function SoundManager(smURL, smID) {
 
         if (instanceOptions.autoLoad || instanceOptions.autoPlay) {
 
-          s._a = (mobileHTML5) ? this.createAudioElement(instanceOptions.url) : new Audio(instanceOptions.url);
+          s._a = (mobileHTML5) ? sm2.createAudioElement(instanceOptions.url) : new Audio(instanceOptions.url);
 
           s._a.load();
 
         } else {
 
           // null for stupid Opera 9.64 case
-          s._a = (mobileHTML5) ? this.createAudioElement() : (isOpera && opera.version() < 10 ? new Audio(null) : new Audio());
+          s._a = (mobileHTML5) ? sm2.createAudioElement() : (isOpera && opera.version() < 10 ? new Audio(null) : new Audio());
 
         }
 

--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -651,18 +651,19 @@ function SoundManager(smURL, smID) {
    *
    * @return {HTMLAudioElement} The audio element created in the dom
    */
-  this.createAudioElement = function () {
+  this.createAudioElement = function (src) {
 
     try {
       var d = doc.createElement('div'),
           a = doc.createElement('audio');
       d.id = 'sm2-html5Audio-wrapper';
       a.id = 'sm2-html5Audio';
+      a.src = (src) ? src : '';
       doc.body.appendChild(d).appendChild(a);
     } catch (e) {} finally {
       return a;
     }
-
+    
   }
 
   /**
@@ -2160,7 +2161,7 @@ function SoundManager(smURL, smID) {
 
             sm2._wD(s.id + ': Cloning Audio() for instance #' + s.instanceCount + '...');
 
-            audioClone = (mobileHTML5) ? this.createAudioElement() : new Audio(s._iO.url);
+            audioClone = (mobileHTML5) ? this.createAudioElement(s._iO.url) : new Audio(s._iO.url);
 
             onended = function() {
               event.remove(audioClone, 'ended', onended);
@@ -3115,7 +3116,7 @@ function SoundManager(smURL, smID) {
 
         if (instanceOptions.autoLoad || instanceOptions.autoPlay) {
 
-          s._a = (mobileHTML5) ? this.createAudioElement() : new Audio(instanceOptions.url);
+          s._a = (mobileHTML5) ? this.createAudioElement(instanceOptions.url) : new Audio(instanceOptions.url);
 
           s._a.load();
 

--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -654,16 +654,14 @@ function SoundManager(smURL, smID) {
   this.createAudioElement = function () {
 
     try {
-      var d = doc.createElement('div');
-      var a = doc.createElement('audio');
+      var d = doc.createElement('div'),
+          a = doc.createElement('audio');
       d.id = 'sm2-html5Audio-wrapper';
-      a.id = 'sm2-html5Audio-tag';
-      d.appendChild(a);
-      doc.body.appendChild(d);
+      a.id = 'sm2-html5Audio';
     } catch (e) {} finally {
       return a;
     }
-    
+
   }
 
   /**

--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -647,6 +647,26 @@ function SoundManager(smURL, smID) {
   };
 
   /**
+   * Creates a <div> element wrapper and an <audio> element inside it
+   *
+   * @return {HTMLAudioElement} The audio element created in the dom
+   */
+  this.createAudioElement = function () {
+
+    try {
+      var d = doc.createElement('div');
+      var a = doc.createElement('audio');
+      d.id = 'sm2-html5Audio-wrapper';
+      a.id = 'sm2-html5Audio-tag';
+      d.appendChild(a);
+      doc.body.appendChild(d);
+    } catch (e) {} finally {
+      return a;
+    }
+    
+  }
+
+  /**
    * Calls the unload() method of a SMSound object by ID.
    *
    * @param {string} sID The ID of the sound
@@ -2141,7 +2161,7 @@ function SoundManager(smURL, smID) {
 
             sm2._wD(s.id + ': Cloning Audio() for instance #' + s.instanceCount + '...');
 
-            audioClone = new Audio(s._iO.url);
+            audioClone = (mobileHTML5) ? this.createAudioElement() : new Audio(s._iO.url);
 
             onended = function() {
               event.remove(audioClone, 'ended', onended);
@@ -3096,13 +3116,14 @@ function SoundManager(smURL, smID) {
 
         if (instanceOptions.autoLoad || instanceOptions.autoPlay) {
 
-          s._a = new Audio(instanceOptions.url);
+          s._a = (mobileHTML5) ? this.createAudioElement() : new Audio(instanceOptions.url);
+
           s._a.load();
 
         } else {
 
           // null for stupid Opera 9.64 case
-          s._a = (isOpera && opera.version() < 10 ? new Audio(null) : new Audio());
+          s._a = (mobileHTML5) ? this.createAudioElement() : (isOpera && opera.version() < 10 ? new Audio(null) : new Audio());
 
         }
 

--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -658,6 +658,7 @@ function SoundManager(smURL, smID) {
           a = doc.createElement('audio');
       d.id = 'sm2-html5Audio-wrapper';
       a.id = 'sm2-html5Audio';
+      doc.body.appendChild(d).appendChild(a);
     } catch (e) {} finally {
       return a;
     }

--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -4337,7 +4337,7 @@ function SoundManager(smURL, smID) {
     }
 
     // double-whammy: Opera 9.64 throws WRONG_ARGUMENTS_ERR if no parameter passed to Audio(), and Webkit + iOS happily tries to load "null" as a URL. :/
-    var a = (Audio !== _undefined ? (isOpera && opera.version() < 10 ? new Audio(null) : new Audio()) : null),
+    var a = (mobileHTML5) ? sm2.getAudioTagElement() : (Audio !== _undefined ? (isOpera && opera.version() < 10 ? new Audio(null) : new Audio()) : null),
         item, lookup, support = {}, aF, i;
 
     function cp(m) {

--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -647,24 +647,17 @@ function SoundManager(smURL, smID) {
   };
 
   /**
-   * Creates a <div> element wrapper and an <audio> element inside it
+   * Gets the <audio> element that already exists in the DOM
    *
    * @return {HTMLAudioElement} The audio element created in the dom
    */
-  this.createAudioElement = function (src) {
+   this.getAudioTagElement = function(src) {
 
-    try {
-      var d = doc.createElement('div'),
-          a = doc.createElement('audio');
-      d.id = 'sm2-html5Audio-wrapper';
-      a.id = 'sm2-html5Audio';
-      a.src = (src) ? src : '';
-      doc.body.appendChild(d).appendChild(a);
-    } catch (e) {} finally {
-      return a;
-    }
-    
-  }
+    var a = doc.getElementById('sm2-html5Audio');
+    a.src = (src) ? src : '';
+    return a;
+
+   };
 
   /**
    * Calls the unload() method of a SMSound object by ID.
@@ -2161,7 +2154,7 @@ function SoundManager(smURL, smID) {
 
             sm2._wD(s.id + ': Cloning Audio() for instance #' + s.instanceCount + '...');
 
-            audioClone = (mobileHTML5) ? sm2.createAudioElement(s._iO.url) : new Audio(s._iO.url);
+            audioClone = (mobileHTML5) ? sm2.getAudioTagElement(s._iO.url) : new Audio(s._iO.url);
 
             onended = function() {
               event.remove(audioClone, 'ended', onended);
@@ -3116,14 +3109,14 @@ function SoundManager(smURL, smID) {
 
         if (instanceOptions.autoLoad || instanceOptions.autoPlay) {
 
-          s._a = (mobileHTML5) ? sm2.createAudioElement(instanceOptions.url) : new Audio(instanceOptions.url);
+          s._a = (mobileHTML5) ? sm2.getAudioTagElement(instanceOptions.url) : new Audio(instanceOptions.url);
 
           s._a.load();
 
         } else {
 
           // null for stupid Opera 9.64 case
-          s._a = (mobileHTML5) ? sm2.createAudioElement() : (isOpera && opera.version() < 10 ? new Audio(null) : new Audio());
+          s._a = (mobileHTML5) ? sm2.getAudioTagElement() : (isOpera && opera.version() < 10 ? new Audio(null) : new Audio());
 
         }
 


### PR DESCRIPTION
Mobile browsers have always had a problem when it comes to playing audio files in the browser. 

Both Chrome & Safari state that a user interaction event - click event - must occur for an audio file to be in the playing state.

Any HTTP request should occur in the same 'stack frame' of the click event.

When using Chrome on Android, we tried to request a URL from the server, to give it to SoundManager that creates an tag dynamically and feed its source with the given URL. The song didn't play.

We found a solution to this problem that is to play a blank mp3 file locally, get the song URL from the server, then replace the currently playing song with the new URL.

Plus, the <audio> tag must not be created dynamically.