### PR TITLE
Add to set the title element for the media information shown in iOS.

### DIFF
--- a/script/soundmanager2-nodebug.js
+++ b/script/soundmanager2-nodebug.js
@@ -64,6 +64,7 @@ function SoundManager(smURL, smID) {
     pan: 0,
     playbackRate: 1,
     stream: true,
+    title: '',
     to: null,
     type: null,
     usePolicyFile: false,
@@ -1332,6 +1333,7 @@ function SoundManager(smURL, smID) {
         } else {
           s._a = (isOpera && opera.version() < 10 ? new Audio(null) : new Audio());
         }
+        s._a.title = instanceOptions.title;
         a = s._a;
         a._called_load = false;
         if (useGlobalHTML5Audio) {

--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -117,6 +117,7 @@ function SoundManager(smURL, smID) {
     pan: 0,                 // "pan" settings, left-to-right, -100 to 100
     playbackRate: 1,        // rate at which to play the sound (HTML5-only)
     stream: true,           // allows playing before entire file has loaded (recommended)
+    title: '',              // wordings shown in iOS lock screen
     to: null,               // position to end playback within a sound (msec), default = end
     type: null,             // MIME-like hint for file pattern / canPlay() tests, eg. audio/mp3
     usePolicyFile: false,   // enable crossdomain.xml request for audio on remote domains (for ID3/waveform access)
@@ -3116,6 +3117,9 @@ function SoundManager(smURL, smID) {
           s._a = (isOpera && opera.version() < 10 ? new Audio(null) : new Audio());
 
         }
+
+        // set the title of the audio
+        s._a.title = instanceOptions.title;
 
         // assign local reference
         a = s._a;


### PR DESCRIPTION
This is a PR for the issue #180. As I also face the issue I decide to fix it by myself. It simply adds the title attribute if the related attribute exists in createSound method. Otherwise it will just use the default options with no title is set. 