### PR TITLE
set debugMode to false by default

### DIFF
--- a/script/soundmanager2-nodebug.js
+++ b/script/soundmanager2-nodebug.js
@@ -21,7 +21,7 @@ function SoundManager(smURL, smID) {
   this.setupOptions = {
     url: (smURL || null),
     flashVersion: 8,
-    debugMode: true,
+    debugMode: false,
     debugFlash: false,
     useConsole: true,
     consoleOnly: true,

--- a/script/soundmanager2.js
+++ b/script/soundmanager2.js
@@ -66,7 +66,7 @@ function SoundManager(smURL, smID) {
 
     url: (smURL || null),             // path (directory) where SoundManager 2 SWFs exist, eg., /path/to/swfs/
     flashVersion: 8,                  // flash build to use (8 or 9.) Some API features require 9.
-    debugMode: true,                  // enable debugging output (console.log() with HTML fallback)
+    debugMode: false,                 // enable debugging output (console.log() with HTML fallback)
     debugFlash: false,                // enable debugging output inside SWF, troubleshoot Flash/browser issues
     useConsole: true,                 // use console.log() if available (otherwise, writes to #soundmanager-debug element)
     consoleOnly: true,                // if console is being used, do not create/write to #soundmanager-debug


### PR DESCRIPTION
It is extremely annoying to have your console flooded with log messages that you don't care about when you are attempting to troubleshoot things that have NOTHING to do with sound.

Logging should never be enabled by default by a library.